### PR TITLE
Add JobRetriever#latest_successful - 84863472

### DIFF
--- a/lib/g5/jobbing/job_fetcher.rb
+++ b/lib/g5/jobbing/job_fetcher.rb
@@ -1,9 +1,9 @@
 module G5::Jobbing::JobFetcher
   include G5::Jobbing::AccessToken
 
-  def fetch_get(url)
+  def fetch_get(url, query_options={})
     response = HTTParty.get(url,
-                            {query:   {access_token: get_access_token},
+                            {query:   query_options.merge({access_token: get_access_token}),
                              headers: {'Content-Type' => 'application/json', 'Accept' => 'application/json'}}
     )
     job_hashes = JSON.parse(response.body)['jobs']

--- a/lib/g5/jobbing/job_retriever.rb
+++ b/lib/g5/jobbing/job_retriever.rb
@@ -16,7 +16,13 @@ class G5::Jobbing::JobRetriever
   end
 
   def latest_successful
-    fetch_get "#{jobs_base_url}?state=completed_with_no_errors&location_setting_urn=#{locations_as_parameter}&distinct_attr=location_setting_urn"
+    query_options = {
+      state: "completed_with_no_errors",
+      location_setting_urn: locations_as_parameter,
+      distinct_attr: "location_setting_urn"
+    }
+
+    fetch_get(jobs_base_url, query_options)
   end
 
   def jobs_url_for_locations

--- a/lib/g5/jobbing/job_retriever.rb
+++ b/lib/g5/jobbing/job_retriever.rb
@@ -6,8 +6,17 @@ class G5::Jobbing::JobRetriever
     self.location_setting_urns = params[:location_setting_urns]
   end
 
-  def perform
+  def current
     fetch_get jobs_url_for_locations
+  end
+
+  def perform
+    warn "[DEPRECATION] `perform` is deprecated. Please use `current` instead."
+    current
+  end
+
+  def latest_successful
+    fetch_get "#{jobs_base_url}?state=completed_with_no_errors&location_setting_urn=#{locations_as_parameter}&distinct_attr=location_setting_urn"
   end
 
   def jobs_url_for_locations

--- a/lib/g5/jobbing/version.rb
+++ b/lib/g5/jobbing/version.rb
@@ -1,5 +1,5 @@
 module G5
   module Jobbing
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/spec/fixtures/successful_jobs.json
+++ b/spec/fixtures/successful_jobs.json
@@ -1,0 +1,26 @@
+{"jobs": [
+    {
+        "uid": "http://localhost:5778/api/v1/jobs/g5-job-6i4h4jo",
+        "urn": "g5-job-6i4h4jo",
+        "location_setting_urn": "int-6i4h4",
+        "state": "started",
+        "error_state": false,
+        "success_state": true,
+        "created_at": "2014-11-10T14:57:49.216-08:00",
+        "updated_at": "2014-11-10T15:12:23.111-08:00",
+        "location_setting_uid": "http://localhost/clients/g5-c-6i4h3un-ethan-bode/locations/g5-cl-6i4h3uo-zoe-krajcik/locations_integration_settings/g5-lis-6i4h3uo",
+        "message": null
+    },
+    {
+        "uid": "http://localhost:5778/api/v1/jobs/g5-job-6i4h4bb",
+        "urn": "g5-job-6i4h4bb",
+        "location_setting_urn": "int-622h4",
+        "state": "started",
+        "error_state": false,
+        "success_state": true,
+        "created_at": "2014-11-10T14:57:19.546-08:00",
+        "updated_at": "2014-11-10T15:12:23.103-08:00",
+        "location_setting_uid": "http://localhost/clients/g5-c-6i4h3un-ethan-bode/locations/g5-cl-6i4h3un-retha-hane/locations_integration_settings/g5-lis-6i4h3un",
+        "message": null
+    }
+]}

--- a/spec/lib/g5/jobbing/job_retriever_spec.rb
+++ b/spec/lib/g5/jobbing/job_retriever_spec.rb
@@ -41,15 +41,22 @@ describe G5::Jobbing::JobRetriever do
     let(:body) { fixture('successful_jobs.json') }
     let(:token) { 'the token' }
     before do
+      query_params = {
+        state: "completed_with_no_errors",
+        location_setting_urn: "loc_urn",
+        distinct_attr: "location_setting_urn",
+        access_token: token,
+      }
+
       expect(G5AuthenticationClient::Client).to receive(:new).and_return(double(:token, get_access_token: token))
       allow(subject).to receive(:jobs_base_url).and_return('api/v1/jobs')
       allow(subject).to receive(:locations_as_parameter).and_return('loc_urn')
       expect(HTTParty).
         to receive(:get).
         with(
-          'api/v1/jobs?state=completed_with_no_errors&location_setting_urn=loc_urn&distinct_attr=location_setting_urn',
+          'api/v1/jobs',
           {
-            query: {access_token: token},
+            query: query_params,
             headers: {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
           }
         ).and_return(double(:response, body: body))

--- a/spec/lib/g5/jobbing/job_retriever_spec.rb
+++ b/spec/lib/g5/jobbing/job_retriever_spec.rb
@@ -6,7 +6,8 @@ describe G5::Jobbing::JobRetriever do
 
   subject { G5::Jobbing::JobRetriever.new(location_setting_urns: [locations_location_setting_urn_1, locations_location_setting_urn_2]) }
 
-  describe :perform do
+  # TODO: convert to vcr
+  describe '#current' do
     let(:body) { fixture('jobs.json') }
     let(:token) { 'the toke' }
     before do
@@ -17,7 +18,7 @@ describe G5::Jobbing::JobRetriever do
                               and_return(double(:response, body: body))
     end
     it 'returns array of jobs' do
-      result = subject.perform
+      result = subject.current
       expect(result.length).to eq(2)
       expect(result.all? { |job| G5::Jobbing::Job == job.class }).to be_truthy
       expect(result.collect(&:location_setting_uid)).to eq(%w(http://localhost/clients/g5-c-6i4h3un-ethan-bode/locations/g5-cl-6i4h3uo-zoe-krajcik/locations_integration_settings/g5-lis-6i4h3uo http://localhost/clients/g5-c-6i4h3un-ethan-bode/locations/g5-cl-6i4h3un-retha-hane/locations_integration_settings/g5-lis-6i4h3un))
@@ -28,10 +29,35 @@ describe G5::Jobbing::JobRetriever do
 
   its (:locations_as_parameter) { is_expected.to eq("[#{locations_location_setting_urn_1},#{locations_location_setting_urn_2}]") }
 
-  describe :jobs_url_for_locations do
-    it 'filters by current and locations_integration_setting UIDs' do
+  describe '#jobs_url_for_locations' do
+    it 'returns a url with current and locations_integration_setting UIDs' do
       expect(subject).to receive(:locations_as_parameter).and_return('loc_param')
       expect(subject.jobs_url_for_locations).to match(/\/api\/v1\/jobs\?current=true&location_setting_urn=loc_param/)
+    end
+  end
+
+  # TODO: convert to vcr
+  describe '#latest_successful' do
+    let(:body) { fixture('successful_jobs.json') }
+    let(:token) { 'the token' }
+    before do
+      expect(G5AuthenticationClient::Client).to receive(:new).and_return(double(:token, get_access_token: token))
+      allow(subject).to receive(:jobs_base_url).and_return('api/v1/jobs')
+      allow(subject).to receive(:locations_as_parameter).and_return('loc_urn')
+      expect(HTTParty).
+        to receive(:get).
+        with(
+          'api/v1/jobs?state=completed_with_no_errors&location_setting_urn=loc_urn&distinct_attr=location_setting_urn',
+          {
+            query: {access_token: token},
+            headers: {'Content-Type' => 'application/json', 'Accept' => 'application/json'}
+          }
+        ).and_return(double(:response, body: body))
+    end
+
+    it 'returns an array of the latest successful jobs of each location setting', vcr: {mode: :once} do
+      result = subject.latest_successful
+      expect(result.all? { |job| G5::Jobbing::Job == job.class }).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Returns each location's latest successful job.  This also deprecates `#perform` in favor of `#current` (which does the same thing but with a more descriptive name).

https://www.pivotaltracker.com/story/show/84863472