### PR TITLE
Expose location_jobs_failing on Job

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,3 @@
+# TBA
+- Add changelog
+- Expose `location_jobs_failing` attribute on Job.

--- a/lib/g5/jobbing/job.rb
+++ b/lib/g5/jobbing/job.rb
@@ -11,6 +11,7 @@ class G5::Jobbing::Job
   attribute :message, String
   attribute :error_state, Boolean
   attribute :success_state, Boolean
+  attribute :location_jobs_failing, Boolean, default: false
 
   def logs_url
     return 'ENV[LOGS_BY_JOB_URL] not set!' if logs_by_job_url.blank?

--- a/spec/lib/g5/jobbing/job_spec.rb
+++ b/spec/lib/g5/jobbing/job_spec.rb
@@ -11,6 +11,7 @@ describe G5::Jobbing::Job do
   let(:message) { 'message' }
   let(:created_at) { DateTime.new(2012, 11, 11) }
   let(:updated_at) { DateTime.new(2013, 10, 10) }
+  let(:location_jobs_failing) { false }
 
   subject { G5::Jobbing::Job.new(uid:                     uid, urn: urn, state: state,
                                  location_setting_uid: location_setting_uid,
@@ -29,6 +30,7 @@ describe G5::Jobbing::Job do
   its(:message) { is_expected.to eq(message) }
   its(:created_at) { is_expected.to eq(created_at) }
   its(:updated_at) { is_expected.to eq(updated_at) }
+  its(:location_jobs_failing) { is_expected.to eq(location_jobs_failing) }
 
   describe 'logs_url' do
     subject { G5::Jobbing::Job.new(urn: 3) }


### PR DESCRIPTION
Boolean attribute on g5-jobs, indicates whether jobs have been consistently failing for a job's location.